### PR TITLE
DN-83 devices: use sessions instead of a db entry for status

### DIFF
--- a/devices/models.py
+++ b/devices/models.py
@@ -26,12 +26,6 @@ class Device(models.Model):
         ("telnet", "Telnet"),
     ]
 
-    STATES = [
-        ("unknown", "❓"),
-        ("reachable", "✅"),
-        ("unreachable", "❌"),
-    ]
-
     name = models.CharField(
         "Hostname",
         primary_key=True,
@@ -54,11 +48,6 @@ class Device(models.Model):
     )
     username = models.CharField(max_length=100)
     password = models.CharField(max_length=100)
-    status = models.CharField(
-        "Status",
-        choices=STATES,
-        default="unknown",
-    )
 
     class Meta:
         constraints = [

--- a/devices/templates/devices/device_list.html
+++ b/devices/templates/devices/device_list.html
@@ -13,48 +13,48 @@
 <div class="table-responsive">
     <table class="table table-striped">
         <thead>
-        <tr>
-            <th>Name</th>
-            <th>IP Address</th>
-            <th>Protocol</th>
-            <th>Type</th>
-            <th>Username</th>
-            <th>Status</th>
-            <th>Actions</th>
-        </tr>
+            <tr>
+                <th>Name</th>
+                <th>IP Address</th>
+                <th>Protocol</th>
+                <th>Type</th>
+                <th>Username</th>
+                <th>Status</th>
+                <th>Actions</th>
+            </tr>
         </thead>
         <tbody>
-        {% if device_list %}
-        {% for device in device_list %}
-        <tr id="device-{{ device.name }}">
-            <td><a href="{{ device.get_absolute_url }}">{{ device.name }}</a></td>
-            <td>{{ device.ip_address }}:{{ device.port }}</td>
-            <td>{{ device.get_protocol_display }}</td>
-            <td>{{ device.get_device_type_display }}</td>
-            <td>{{ device.username }}</td>
-            <td class="status">
-                <span class="connection-status">{{ device.get_status_display }}</span>
-                <span id="{{ device.name }}-spinner" class="htmx-indicator">
+            {% if device_list %}
+            {% for device in device_list %}
+            <tr id="device-{{ device.name }}">
+                <td><a href="{{ device.get_absolute_url }}">{{ device.name }}</a></td>
+                <td>{{ device.ip_address }}:{{ device.port }}</td>
+                <td>{{ device.get_protocol_display }}</td>
+                <td>{{ device.get_device_type_display }}</td>
+                <td>{{ device.username }}</td>
+                <td class="status">
+                    <span class="connection-status">{{ device.session_status }}</span>
+                    <span id="{{ device.name }}-spinner" class="htmx-indicator">
                         <span class="spinner-grow spinner-grow-sm" role="status"></span>
                     </span>
-            </td>
-            <td>
-                <button title="Check status" hx-get="{% url 'device-check' device.name %}"
+                </td>
+                <td>
+                    <button title="Check status" hx-get="{% url 'device-check' device.name %}"
                         hx-target="#device-{{ device.name }} .connection-status" hx-swap="innerHTML"
                         hx-indicator="#{{ device.name }}-spinner" class="btn btn-sm btn-info device-check">
-                    <i class="bi bi-check2"></i>
-                </button>
-                <a href="{% url 'device-delete' device.name %}" class="btn btn-sm btn-danger" title="Delete">
-                    <i class="bi bi-trash"></i>
-                </a>
-            </td>
-        </tr>
-        {% endfor %}
-        {% else %}
-        <tr>
-            <td colspan="100%">No devices yet.</td>
-        </tr>
-        {% endif %}
+                        <i class="bi bi-check2"></i>
+                    </button>
+                    <a href="{% url 'device-delete' device.name %}" class="btn btn-sm btn-danger" title="Delete">
+                        <i class="bi bi-trash"></i>
+                    </a>
+                </td>
+            </tr>
+            {% endfor %}
+            {% else %}
+            <tr>
+                <td colspan="100%">No devices yet.</td>
+            </tr>
+            {% endif %}
         </tbody>
     </table>
 </div>

--- a/devices/views.py
+++ b/devices/views.py
@@ -8,7 +8,7 @@ from devices.forms import DeviceForm
 
 from .models import Device
 
-state_map = {
+STATE_MAP = {
     "unknown": "❓",
     "reachable": "✅",
     "unreachable": "❌",
@@ -27,7 +27,7 @@ class DeviceListView(generic.ListView):
         session_devices = self.request.session.get("devices", {})
         for device in context["device_list"]:
             status = session_devices.get(str(device.pk), {}).get("status", "unknown")
-            device.session_status = state_map[status]
+            device.session_status = STATE_MAP[status]
 
         return context
 
@@ -75,5 +75,5 @@ def device_check(request, pk):
     return render(
         request,
         "devices/partials/device_status_cell.html",
-        {"status": state_map[new_status]},
+        {"status": STATE_MAP[new_status]},
     )


### PR DESCRIPTION
Use sessions instead of db entries for the device statuses for slightly better performance
